### PR TITLE
Remove need for running initial checkpoint workflow

### DIFF
--- a/app_docs/README.md
+++ b/app_docs/README.md
@@ -28,8 +28,7 @@ Target users include organizations that use both CrowdStrike IDP and ServiceNow 
     - ServiceNow instance URL
     - Service account credentials
 7. Configure Workflow parameters.
-8. Execute Initialize or Reset checkpoint-LatestSysUpdatedOn workflow
-9. Execute ServiceNow to IDP policy rules synchronizer workflow
+8. Execute ServiceNow to IDP policy rules synchronizer workflow
 
 ## 4. User Guide
 ### ServiceNow CMDB Table
@@ -61,7 +60,7 @@ Workflow configuration to be done during app installation.
 ![Workflow settings](wfSettings.png)
 
 ##### Initialize or Reset checkpoint-LatestSysUpdatedOn
-This workflow must be executed at least once after installation to establish the initial checkpoint. It can also be triggered manually to reset the checkpoint time when records need to be resynchronized from a specific point in time. The workflow is parametrized and the default checkpoint time is set to 1970-01-01 00:00:00 which can be updated before triggering this workflow.
+This workflow can be triggered manually to reset the checkpoint time when records need to be resynchronized from a specific point in time. The workflow is parametrized and the default checkpoint time is set to 1970-01-01 00:00:00 which can be updated before triggering this workflow.
 
 ##### ServiceNow to IDP policy rules synchronizer
 This workflow serves as the main execution engine of the application, orchestrating all artifacts to perform the synchronization process. Upon completion of each run, it writes a summary record to LogScale that can be leveraged to create NG-SIEM dashboards and alerts for monitoring synchronization status.

--- a/workflows/ServiceNow_to_IDP_policy_rules_synchronizer.yml
+++ b/workflows/ServiceNow_to_IDP_policy_rules_synchronizer.yml
@@ -40,6 +40,15 @@ trigger:
         - create_variable_b321beaa
     event: Schedule
 actions:
+    UpdateVariable:
+        next:
+            - service_now_cmdb_table_api_23c0ead3
+        id: 6c6eab39063fa3b72d98c82af60deb8a
+        class: UpdateVariable
+        properties:
+            WorkflowCustomVariable:
+                v_latestSysUpdatedOn: '${data[''get_object_from_servicenow_idp_app_state_12f7153b.CustomStorage.Collection_servicenow_idp_app_state.latestSysUpdatedOn'']== null || data[''get_object_from_servicenow_idp_app_state_12f7153b.CustomStorage.Collection_servicenow_idp_app_state.latestSysUpdatedOn'']== "" ? "1970-01-01 00:00:00" : data[''get_object_from_servicenow_idp_app_state_12f7153b.CustomStorage.Collection_servicenow_idp_app_state.latestSysUpdatedOn'']}'
+        version_constraint: ~1
     add_object_to_servicenow_idp_app_state_1783d1b9:
         next:
             - write_to_log_repo_468fe687
@@ -61,10 +70,12 @@ actions:
                         description: Synchronization checkpoint storage
                         format: foundryCustomStorageObjectKey
                         type: string
+                    v_latestSysUpdatedOn:
+                        type: string
                 type: object
     get_object_from_servicenow_idp_app_state_12f7153b:
         next:
-            - service_now_cmdb_table_api_23c0ead3
+            - UpdateVariable
         id: collections.servicenow_idp_app_state.get
         properties:
             custom_storage_object_key: ${WorkflowCustomVariable.servicenowIdpAppState}
@@ -75,14 +86,14 @@ actions:
         properties:
             params:
                 query:
-                    sysparm_query: sys_updated_on>=${get_object_from_servicenow_idp_app_state_12f7153b.CustomStorage.Collection_servicenow_idp_app_state.latestSysUpdatedOn}
+                    sysparm_query: sys_updated_on>=${data['WorkflowCustomVariable.v_latestSysUpdatedOn']}
     transform_rules_aec4b131:
         next:
             - add_object_to_servicenow_idp_app_state_1783d1b9
         id: functions.servicenowToIdpPolicyRulesTransformer.transform_rules
         properties:
             lastSyncTime: ${get_object_from_servicenow_idp_app_state_12f7153b.CustomStorage.Collection_servicenow_idp_app_state.lastSyncTime}
-            latestSysUpdatedOn: ${get_object_from_servicenow_idp_app_state_12f7153b.CustomStorage.Collection_servicenow_idp_app_state.latestSysUpdatedOn}
+            latestSysUpdatedOn: ${data['WorkflowCustomVariable.v_latestSysUpdatedOn']}
             result:
                 result: ${service_now_cmdb_table_api_23c0ead3.API_Integration.Custom_service_now_cmdb.service_now_cmdb_table_api.body.result}
     write_to_log_repo_468fe687:


### PR DESCRIPTION
Update sync workflow to take into account empty checkpoint, this removes the need for dedicated initialization workflow to be run. The Initialization workflow still exists, so it can used for resetting or updating checkpoint as needed