### PR TITLE
Add missing dependabot ignore rules for unapproved GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,10 @@ updates:
       timezone: "UTC"
     ignore:
       - dependency-name: "actions/checkout"
-        versions: [">=6.0.2"]
+        versions: [">=6.0.3"]
       - dependency-name: "actions/setup-node"
-        versions: [">=6.2.0"]
+        versions: [">=6.3.0"]
       - dependency-name: "actions/setup-python"
-        versions: [">=6.1.0"]
+        versions: [">=6.3.0"]
       - dependency-name: "actions/upload-artifact"
         versions: [">=6.0.0"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,4 @@ updates:
       - dependency-name: "actions/setup-python"
         versions: [">=6.3.0"]
       - dependency-name: "actions/upload-artifact"
-        versions: [">=6.0.0"]
+        versions: [">=7.0.0"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
         versions: [">=6.2.0"]
       - dependency-name: "actions/setup-python"
         versions: [">=6.1.0"]
+      - dependency-name: "actions/upload-artifact"
+        versions: [">=6.0.0"]


### PR DESCRIPTION
Adds and updates dependabot ignore rules for GitHub Actions not in the CrowdStrike enterprise allow-list.

New ignore rules added:
- `actions/upload-artifact` >=6.0.0

Updated thresholds to allow approved versions:
- `actions/checkout`: >=6.0.2 -> >=6.0.3
- `actions/setup-node`: >=6.2.0 -> >=6.3.0
- `actions/setup-python`: >=6.1.0 -> >=6.3.0