### PR TITLE
Fail E2E test when API credential prompt is missing

### DIFF
--- a/e2e/src/pages/AppCatalogPage.ts
+++ b/e2e/src/pages/AppCatalogPage.ts
@@ -204,6 +204,14 @@ export class AppCatalogPage extends BasePage {
    * Fills in dummy values for all configuration fields and clicks through multiple settings.
    */
   private async configureApiIntegrationIfNeeded(): Promise<void> {
+    // Verify the credential prompt appears — this app requires API credentials
+    const firstInput = this.page.locator('input[type="text"], input[type="url"], input[type="password"]');
+    try {
+      await firstInput.first().waitFor({ state: 'visible', timeout: 15000 });
+    } catch (error) {
+      throw new Error('This app should prompt for API credentials');
+    }
+
     let configCount = 0;
     let hasNextSetting = true;
 

--- a/e2e/src/pages/AppCatalogPage.ts
+++ b/e2e/src/pages/AppCatalogPage.ts
@@ -205,9 +205,10 @@ export class AppCatalogPage extends BasePage {
    */
   private async configureApiIntegrationIfNeeded(): Promise<void> {
     // Verify the credential prompt appears — this app requires API credentials
-    const firstInput = this.page.locator('input[type="text"], input[type="url"], input[type="password"]');
+    // Check for password fields specifically since workflow config screens only have text fields
+    const passwordInput = this.page.locator('input[type="password"]');
     try {
-      await firstInput.first().waitFor({ state: 'visible', timeout: 15000 });
+      await passwordInput.first().waitFor({ state: 'visible', timeout: 15000 });
     } catch (error) {
       throw new Error('This app should prompt for API credentials');
     }


### PR DESCRIPTION
The `configureApiIntegrationIfNeeded()` method silently returned when credential input fields weren't found during install. Since this app always requires API credentials, the test should fail if the prompt doesn't appear rather than passing with unconfigured credentials.