### PR TITLE
Add time zone selection to e2e install test

### DIFF
--- a/e2e/tests/app-install.setup.ts
+++ b/e2e/tests/app-install.setup.ts
@@ -47,6 +47,15 @@ setup('install app', async ({ page }) => {
       const firstOption = page.locator('[role="option"]').first();
       await firstOption.waitFor({ state: 'visible', timeout: 5000 });
       await firstOption.click();
+
+      // Select time zone (required when a schedule frequency is chosen)
+      const tzDropdown = page.getByLabel('Time zone');
+      if (await tzDropdown.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await tzDropdown.click();
+        const tzOption = page.locator('[role="option"]').first();
+        await tzOption.waitFor({ state: 'visible', timeout: 5000 });
+        await tzOption.click();
+      }
     },
   });
 });


### PR DESCRIPTION
The app requires a time zone when a schedule frequency is selected in the
install settings. Without selecting a value, form validation blocks the
"Install app" button from being clicked.

This adds time zone dropdown selection after the "How often" frequency is
chosen, matching the current app behavior.