### PR TITLE
Upgrade @crowdstrike/foundry-playwright to 0.5.4

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@crowdstrike/foundry-playwright": "0.5.3",
+        "@crowdstrike/foundry-playwright": "0.5.4",
         "@types/node": "25.1.0"
       },
       "engines": {
@@ -17,9 +17,9 @@
       }
     },
     "node_modules/@crowdstrike/foundry-playwright": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.3.tgz",
-      "integrity": "sha512-sB0Oz0MkgO4bOxbjx0FpQDAsQwTMCP4ndSjdrXViiFPKjLpmbAFKgY5A/D47GhTxYcBJQ3XxNryu7gcwEYDwSA==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@crowdstrike/foundry-playwright/-/foundry-playwright-0.5.4.tgz",
+      "integrity": "sha512-1ht1Eos9M8Lhrz84E00s/+x0O+ir2Vb+s8a262CGZ9efjnofGGg158upTc7r4cjbs6DqFp7sR7Q25bIaylsyzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
-    "@crowdstrike/foundry-playwright": "0.5.3",
+    "@crowdstrike/foundry-playwright": "0.5.4",
     "@types/node": "25.1.0"
   }
 }


### PR DESCRIPTION
Picks up configurable extensionTimeout for SocketNavigationPage extension methods, fixing flaky extension-render tests in slower CI environments.