### PR TITLE
Handle non-deterministic install screen order

### DIFF
--- a/e2e/tests/app-install.setup.ts
+++ b/e2e/tests/app-install.setup.ts
@@ -7,54 +7,63 @@ setup('install app', async ({ page }) => {
 
   await catalog.installApp(config.appName, {
     configureSettings: async (page) => {
-      // Setting 1: ServiceNow API integration (basic auth)
-      await page.getByRole('textbox', { name: 'Name', exact: true }).fill('ServiceNow Test Instance');
-      await page.getByRole('textbox', { name: 'Host', exact: true }).fill(process.env.SERVICENOW_INSTANCE_URL || 'https://example.service-now.com');
-      await page.getByRole('textbox', { name: 'Username' }).fill(process.env.SERVICENOW_USERNAME || 'foundry_test_user');
-      await page.getByRole('textbox', { name: 'Password' }).fill(process.env.SERVICENOW_PASSWORD || 'test-password');
-
-      // Navigate to Setting 2: Workflow configuration fields
       const nextButton = page.getByRole('button', { name: /next setting/i });
-      await nextButton.click();
-      await page.waitForLoadState('domcontentloaded').catch(() => {});
 
-      await page.getByLabel('CmdbAppNameColumn').fill('name');
-      await page.getByLabel('HostGuidColumn').fill('host_guid');
-      await page.getByLabel('HostRetiredColumn').fill('u_host_retired');
-      await page.getByLabel('IdpActionColumn').fill('u_idp_action');
-      await page.getByLabel('IdpEnabledColumn').fill('u_idp_enabled');
-      await page.getByLabel('IdpRuleNamePrefix').fill('SN-');
-      await page.getByLabel('IdpSimulationModeColumn').fill('u_idp_simulation');
-      await page.getByLabel('IdpTriggerColumn').fill('u_idp_trigger');
-      await page.getByLabel('SysUpdatedOnColumn').fill('sys_updated_on');
-      await page.getByLabel('TableName').fill('cmdb_ci_server');
-      await page.getByLabel('UserGuidColumn').fill('user_guid');
-      await page.getByLabel('UserRetiredColumn').fill('u_user_retired');
-      await page.getByLabel('SysParamLimit').fill('100');
+      // Fill each settings screen in whatever order the app presents them.
+      // Detect the current screen by checking for a unique field.
+      for (let screen = 0; screen < 2; screen++) {
+        if (await page.getByRole('textbox', { name: 'Username' }).isVisible({ timeout: 3000 }).catch(() => false)) {
+          // ServiceNow API integration screen — Name, Host, Username, Password
+          await page.getByRole('textbox', { name: 'Name', exact: true }).fill('ServiceNow Test Instance');
+          await page.getByRole('textbox', { name: 'Host', exact: true }).fill(process.env.SERVICENOW_INSTANCE_URL || 'https://example.service-now.com');
+          await page.getByRole('textbox', { name: 'Username' }).fill(process.env.SERVICENOW_USERNAME || 'foundry_test_user');
+          await page.getByRole('textbox', { name: 'Password' }).fill(process.env.SERVICENOW_PASSWORD || 'test-password');
+        } else {
+          // Workflow configuration screen — column mappings, email, schedule
+          await page.getByLabel('CmdbAppNameColumn').fill('name');
+          await page.getByLabel('HostGuidColumn').fill('host_guid');
+          await page.getByLabel('HostRetiredColumn').fill('u_host_retired');
+          await page.getByLabel('IdpActionColumn').fill('u_idp_action');
+          await page.getByLabel('IdpEnabledColumn').fill('u_idp_enabled');
+          await page.getByLabel('IdpRuleNamePrefix').fill('SN-');
+          await page.getByLabel('IdpSimulationModeColumn').fill('u_idp_simulation');
+          await page.getByLabel('IdpTriggerColumn').fill('u_idp_trigger');
+          await page.getByLabel('SysUpdatedOnColumn').fill('sys_updated_on');
+          await page.getByLabel('TableName').fill('cmdb_ci_server');
+          await page.getByLabel('UserGuidColumn').fill('user_guid');
+          await page.getByLabel('UserRetiredColumn').fill('u_user_retired');
+          await page.getByLabel('SysParamLimit').fill('100');
 
-      // Email recipient (combobox)
-      const toCombobox = page.getByRole('combobox', { name: 'Recipients' });
-      if (await toCombobox.isVisible({ timeout: 2000 }).catch(() => false)) {
-        await toCombobox.click();
-        await toCombobox.fill('test@example.com');
-        await page.keyboard.press('Enter');
-        await page.locator('body').click({ position: { x: 0, y: 0 } });
-      }
+          // Email recipient (combobox)
+          const toCombobox = page.getByRole('combobox', { name: 'Recipients' });
+          if (await toCombobox.isVisible({ timeout: 2000 }).catch(() => false)) {
+            await toCombobox.click();
+            await toCombobox.fill('test@example.com');
+            await page.keyboard.press('Enter');
+            await page.locator('body').click({ position: { x: 0, y: 0 } });
+          }
 
-      // "How often" timer/schedule dropdown
-      const howOftenDropdown = page.getByLabel('How often').or(page.locator('button', { hasText: 'Select interval' }));
-      await howOftenDropdown.click();
-      const firstOption = page.locator('[role="option"]').first();
-      await firstOption.waitFor({ state: 'visible', timeout: 5000 });
-      await firstOption.click();
+          // "How often" timer/schedule dropdown
+          const howOftenDropdown = page.getByLabel('How often').or(page.locator('button', { hasText: 'Select interval' }));
+          await howOftenDropdown.click();
+          const firstOption = page.locator('[role="option"]').first();
+          await firstOption.waitFor({ state: 'visible', timeout: 5000 });
+          await firstOption.click();
 
-      // Select time zone (required when a schedule frequency is chosen)
-      const tzDropdown = page.getByLabel('Time zone');
-      if (await tzDropdown.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await tzDropdown.click();
-        const tzOption = page.locator('[role="option"]').first();
-        await tzOption.waitFor({ state: 'visible', timeout: 5000 });
-        await tzOption.click();
+          // Select time zone (required when a schedule frequency is chosen)
+          const tzDropdown = page.getByLabel('Time zone');
+          if (await tzDropdown.isVisible({ timeout: 3000 }).catch(() => false)) {
+            await tzDropdown.click();
+            const tzOption = page.locator('[role="option"]').first();
+            await tzOption.waitFor({ state: 'visible', timeout: 5000 });
+            await tzOption.click();
+          }
+        }
+
+        if (await nextButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+          await nextButton.click();
+          await page.waitForLoadState('domcontentloaded').catch(() => {});
+        }
       }
     },
   });


### PR DESCRIPTION
The platform no longer guarantees which settings screen appears first during app installation. The e2e install test was assuming the API integration screen (Name, Host, Username, Password) always showed before the workflow configuration screen, causing a timeout when the order was reversed.

The fix detects the current screen by checking for a unique field (Username textbox) and fills accordingly, looping through both screens regardless of presentation order. This follows the same pattern used in PR #46 of foundry-sample-insider-risk-sailpoint.