### PR TITLE
Remove personal contact email from API integration spec

### DIFF
--- a/api-integrations/servicenow_table_int_4.json
+++ b/api-integrations/servicenow_table_int_4.json
@@ -8,9 +8,6 @@
     }
   },
   "info": {
-    "contact": {
-      "email": "subramaniam.arunachalam@crowdstrike.com"
-    },
     "description": "Allows you to perform create, read, update and delete (CRUD) operations on existing tables",
     "title": "service now cmdb",
     "version": ""


### PR DESCRIPTION
## Summary

Removes the `info.contact.email` field from the OpenAPI spec(s) in `api-integrations/`. This field contained a personal CrowdStrike employee email address, which is inappropriate to expose in a public repository.

The field is optional per the OpenAPI specification and is not used by Foundry at runtime.

## Change

- Removed `"contact": { "email": "..." }` block from `info` section
- No functional change — spec behaviour is identical